### PR TITLE
Revert "#48 limit input text for voicing to exclude API exploiting"

### DIFF
--- a/src/main/kotlin/com/kvsiniuk/parleybot/adapter/telegram/handler/text/VoiceCmdHandler.kt
+++ b/src/main/kotlin/com/kvsiniuk/parleybot/adapter/telegram/handler/text/VoiceCmdHandler.kt
@@ -17,7 +17,6 @@ class VoiceCmdHandler(
 ) : TelegramUpdateHandler {
     override fun process(update: TelegramUpdateMessage) {
         update.replyText
-            ?.substring(0..400)
             ?.takeIf { StringUtils.isNotBlank(it) }
             ?.let { textToSpeechPort.translateToVoice(it) }
             ?.also { telegramMessagePort.sendVoice(update.chatId, it) }


### PR DESCRIPTION
This reverts commit fbe225978961daba216a337d334be35e1b87e639.